### PR TITLE
Chore: fix trailing comma in .mcp.json github server entry (valid JSON)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -34,7 +34,7 @@
     },
     "github": {
       "type": "http",
-      "url": "https://api.githubcopilot.com/mcp",
+      "url": "https://api.githubcopilot.com/mcp"
     }
   }
 }


### PR DESCRIPTION
Fix invalid JSON in `.mcp.json` by removing the trailing comma after the GitHub MCP server `url` field.

Why
- Trailing comma breaks strict JSON parsers used by some MCP clients.

Change
- Remove trailing comma in the `github` server block.

Validation
- File now parses as valid JSON.
